### PR TITLE
Checkbox Case

### DIFF
--- a/src/app/pages/aria-conditional-attr/aria-conditional-attr.component.html
+++ b/src/app/pages/aria-conditional-attr/aria-conditional-attr.component.html
@@ -17,7 +17,7 @@
 </div>
 
 <!-- Invalid: Native checkbox with aria-checked -->
-<input type="checkbox" id="cb2" [attr.aria-checked]="'false'" />
+<input type="checkbox" id="cb2" [attr.aria-checked]="'false'" checked/>
 <label for="cb2">Invalid checkbox</label>
 
 <!-- Invalid: Grid row with conditional attributes -->


### PR DESCRIPTION
currently aria-conditional-attr only flags a checkbox if aria-checked and native checkbox state are out of sync.  I filed an issue to change this to just always flag when aria-checked is present where a native checkbox state will suffice.  For now, we make the test case fit the current behavior.  