### PR TITLE
dlitem page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,6 +42,7 @@ import { RoleImgAltComponent } from './pages/role-img-alt/role-img-alt.component
 import { TdHeadersAttrComponent } from './pages/td-headers-attr/td-headers-attr.component';
 import { AriaHiddenFocusComponent } from './pages/aria-hidden-focus/aria-hidden-focus.component';
 import { DefinitionListComponent } from './pages/definition-list/definition-list.component';
+import { DlItemComponent } from './pages/dlitem/dlitem.component';
 
 export const routes: Routes = [
     { path: 'aria-valid-attr-value', component: AriaValidAttrValueComponent },
@@ -65,6 +66,7 @@ export const routes: Routes = [
     { path: 'color-contrast', component: ColorContrastComponent },
     { path: 'color-contrast/style-variants', component: StyleVariantsComponent },
     { path: 'definition-list', component: DefinitionListComponent },
+    { path: 'dlitem', component: DlItemComponent },    
     { path: 'frame-title', component: FrameTitleComponent },    
     { path: 'focus-visible', component: FocusVisibleComponent },
     { path: 'headings', component: HeadingsComponent },

--- a/src/app/pages/dlitem/dlitem.component.html
+++ b/src/app/pages/dlitem/dlitem.component.html
@@ -1,0 +1,36 @@
+<!-- http://localhost:4000/dlitem -->
+<div>
+    <h2>Valid</h2>
+    <div>
+        <dl>
+            <dt>Car</dt>
+            <dd>Tesla</dd>
+            <dt>Truck</dt>
+            <dd>Ford</dd>
+        </dl>
+    </div>
+    <h2>Invalid</h2>
+    <div>
+        <h2>Case 1: Basic Stray elements</h2>
+        <div>
+            <dt>Type</dt>
+            <dd>Definition</dd>
+            <dt>Lonely Type</dt>
+        </div>
+        <h2>Case 2: Invalid Element</h2>
+        <div>
+            <dt>Type</dt>
+            <dd>Definition</dd>
+            <dt>Lonely Type</dt>
+            <button>Hello</button>
+        </div>
+        <h2>Case 3: Should be 2 separate DL's</h2>
+        <div>
+            <dt>Type 1</dt>
+            <dd>Definition 1</dd>
+            <button>Hello</button>
+            <dt>Type 2</dt>
+            <dd>Definition 2</dd>
+        </div>
+    </div>
+</div>

--- a/src/app/pages/dlitem/dlitem.component.ts
+++ b/src/app/pages/dlitem/dlitem.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dlitem',
+  standalone: true,
+  imports: [],
+  templateUrl: './dlitem.component.html',
+  styles: ``
+})
+export class DlItemComponent {}


### PR DESCRIPTION
where definition-list checks that the contents of a `<dl>` are valid, dlitem wraps stray contents without a `<dl>` tag.  